### PR TITLE
Update verifier to correctly handle SWIXes

### DIFF
--- a/switools/signaturelib.py
+++ b/switools/signaturelib.py
@@ -37,13 +37,13 @@ def extractSwadapt( swi, workDir ):
    cmd = [ "unzip", "-o", "-qq", os.path.abspath( swi ), "swadapt" ]
    return runCmd( cmd, workDir )
 
-def checkIsSwiFile( swi, workDir ):
+def checkIsSwiFile( swi ):
    if not os.path.isfile( swi ):
       return False
+   fileExt = os.path.splitext( swi )[ -1 ]
+   versionFileName = 'manifest.txt' if fileExt == '.swix' else 'version'
    with zipfile.ZipFile( swi ) as zf:
-      if 'version' not in zf.namelist():
-         return False
-      return True
+      return versionFileName in zf.namelist()
 
 def adaptSwi( swi, optimImage, optim, workDir ):
    cmd = [ "%s/swadapt" % workDir, os.path.abspath( swi ), optimImage, optim ]

--- a/switools/swisignature.py
+++ b/switools/swisignature.py
@@ -206,7 +206,7 @@ def signSwiAll( workDir, swi, signingCertFile, rootCaFile, signatureFile=None, s
    # handling that extraction. swadapt is found inside the image itself and is a
    # statically linked i386 binary.
    # Make sure the image we got is a swi file
-   if not signaturelib.checkIsSwiFile( swi, workDir ):
+   if not signaturelib.checkIsSwiFile( swi ):
       raise SwiSignException( SWI_SIGN_RESULT.ERROR_NOT_A_SWI,
                               "Error: '%s' does not look like an EOS image" % swi )
 

--- a/switools/verifyswi.py
+++ b/switools/verifyswi.py
@@ -223,7 +223,7 @@ def verifyAllSwi( workDir, swi, rootCA=ROOT_CA_FILE_NAME ):
    subImageError = False
 
    # Make sure the image we got is a swi file
-   if not signaturelib.checkIsSwiFile( swi, workDir ):
+   if not signaturelib.checkIsSwiFile( swi ):
       print( "Error: '%s' does not look like an EOS image" % swi )
       return VERIFY_SWI_RESULT.ERROR_NOT_A_SWI
    optims = signaturelib.getOptimizations( swi, workDir )

--- a/tests/test_swisignature.py
+++ b/tests/test_swisignature.py
@@ -62,8 +62,9 @@ class TestSwiSignature( unittest.TestCase ):
         return sha256sum.hexdigest()
 
     def _verifySignature( self, filename ):
-        retCode = verifyswi.verifySwi( filename, rootCA=self.root_crt )
-        self.assertEqual( retCode, 0 )
+        with tempfile.TemporaryDirectory( prefix="swix-verify-" ) as workDir:
+            retCode = verifyswi.verifyAllSwi( workDir, filename, self.root_crt )
+            self.assertEqual( retCode, 0 )
 
     def test_prepare_return_hexdigest( self ):
         hexdigest = swisignature.prepareSwi( self.test_swi )

--- a/tests/test_swixsignature.py
+++ b/tests/test_swixsignature.py
@@ -40,7 +40,7 @@ class TestSwiSignature( unittest.TestCase ):
     def _makeTestSwix( self, filename ):
         path = os.path.join( self.test_dir, filename )
         with zipfile.ZipFile( path, 'w' ) as swix:
-            swix.writestr( 'manifest', 'some rpms names here' )
+            swix.writestr( 'manifest.txt', 'some rpms names here' )
         return path
 
     def _validateNullSig( self, filename, size=8192, exists=True ):
@@ -62,8 +62,9 @@ class TestSwiSignature( unittest.TestCase ):
         return sha256sum.hexdigest()
 
     def _verifySignature( self, filename ):
-        retCode = verifyswi.verifySwi( filename, rootCA=self.root_crt )
-        self.assertEqual( retCode, 0 )
+        with tempfile.TemporaryDirectory( prefix="swix-verify-" ) as workDir:
+            retCode = verifyswi.verifyAllSwi( workDir, filename, self.root_crt )
+            self.assertEqual( retCode, 0 )
 
     def test_prepare_return_hexdigest( self ):
         hexdigest = swisignature.prepareSwi( self.test_swix )


### PR DESCRIPTION
The verifier incorrectly expects a `version` file to be present in SWIX files. The SWIX equivalent of the `version` file is `manifest.txt`. 

While we have tests that validate signing and verification of SWIXes, our tests were invoking a helper rather than the top-level verifier function, so we were missing coverage for some of our verification logic. I updated the tests, checked that they fail with the expected error, then made my fix and checked that they now pass.